### PR TITLE
Revert "Hardcode gradle test plugin version"

### DIFF
--- a/dist/thundra.gradle.ejs
+++ b/dist/thundra.gradle.ejs
@@ -4,7 +4,7 @@ initscript {
     }
 
     dependencies {
-        classpath 'io.thundra.agent:thundra-gradle-test-plugin:0.0.5'
+        classpath 'io.thundra.agent:thundra-gradle-test-plugin:<%= thundra.gradlePluginVersion %>'
     }
 }
 

--- a/templates/thundra.gradle.ejs
+++ b/templates/thundra.gradle.ejs
@@ -4,7 +4,7 @@ initscript {
     }
 
     dependencies {
-        classpath 'io.thundra.agent:thundra-gradle-test-plugin:0.0.5'
+        classpath 'io.thundra.agent:thundra-gradle-test-plugin:<%= thundra.gradlePluginVersion %>'
     }
 }
 


### PR DESCRIPTION
We've decided not to update Thundra Gradle Test Plugin at the moment. So, the hardcoded version to prevent breaking changes shipping into action is not necessary anymore.

Reverting https://github.com/thundra-io/thundra-gradle-test-action/pull/10 with this PR.